### PR TITLE
feat: Apply 3D tilt to ExperienceCard and continuous skill hover anim…

### DIFF
--- a/client/src/components/home/ExperienceCard.tsx
+++ b/client/src/components/home/ExperienceCard.tsx
@@ -1,4 +1,5 @@
 // components/ExperienceCard.tsx
+import Tilt from 'react-parallax-tilt';
 import { Experience } from '../../types/index';
 
 interface ExperienceCardProps {
@@ -34,10 +35,18 @@ export const ExperienceCard = ({ experience }: ExperienceCardProps) => {
   };
 
   return (
-    <div className="card hover-lift relative">
-      <div className="absolute top-6 right-6 text-sm text-primary-300 dark:text-dark-200">
-        {getDateDisplay()}
-      </div>
+    <Tilt
+      tiltMaxAngleX={3}
+      tiltMaxAngleY={3}
+      perspective={1000}
+      transitionSpeed={1000}
+      scale={1.02}
+      className="w-full h-full"
+    >
+      <div className="card relative">
+        <div className="absolute top-6 right-6 text-sm text-primary-300 dark:text-dark-200">
+          {getDateDisplay()}
+        </div>
       <h3 className="text-gradient pr-24">{experience.title}</h3>
       <p className="font-semibold text-accent-coral dark:text-accent-gold">
         {experience.company}
@@ -46,5 +55,6 @@ export const ExperienceCard = ({ experience }: ExperienceCardProps) => {
         {experience.description}
       </p>
     </div>
+    </Tilt>
   );
 };

--- a/client/src/components/home/SkillSection.tsx
+++ b/client/src/components/home/SkillSection.tsx
@@ -46,7 +46,7 @@ export default function SkillsSection() {
                       <img
                         src={skill.iconUrl}
                         alt={skill.name}
-                        className="w-8 h-8 object-contain group-hover:animate-jump-spin"
+                        className="w-8 h-8 object-contain group-hover:animate-continuous-spin"
                       />
                     )}
                     <span className="font-medium block break-words whitespace-normal">{skill.name}</span>

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -20,6 +20,15 @@
   }
 }
 
+@keyframes continuous-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @layer components {
   .btn-primary {
     @apply px-4 py-2 rounded-lg bg-primary-400 hover:bg-primary-500 text-white 
@@ -168,5 +177,9 @@
   }
   .animate-jump-spin {
     animation: jump-and-spin 0.5s ease-in-out;
+  }
+
+  .group-hover\:animate-continuous-spin:hover {
+    animation: continuous-spin 1s linear infinite;
   }
 }


### PR DESCRIPTION
…ation

This commit introduces two visual enhancements:

1.  The 3D card tilt effect, previously only on Project cards, has now been applied to Experience cards for a consistent look and feel. This involved importing the `react-parallax-tilt` component into `ExperienceCard.tsx` and wrapping the card content, mirroring the implementation in `ProjectCard.tsx`. The `hover-lift` class was removed to prevent conflicts with the tilt effect.

2.  The hover animation for skill icons in the Skills section has been updated from a single flip to a continuous rotation. This was achieved by:
    - Defining a new CSS `@keyframes continuous-spin` rule.
    - Creating a new utility class `.group-hover\:animate-continuous-spin:hover` that uses this animation.
    - Updating `SkillSection.tsx` to apply the new class to skill icons.

The development server starts successfully after these changes, and initial dependency and syntax issues identified during testing were resolved.